### PR TITLE
Optimize landmark rendering and add Tokyo landmarks

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -17,7 +17,7 @@ const AppController = {
         if (!compassCircle || AppState.ui.landmarkElementsCreated) return;
         
         // Create elements for each landmark
-        Object.keys(landmarks).forEach(landmarkId => {
+        Object.entries(landmarks).forEach(([landmarkId, landmark]) => {
             // Create compass line
             const lineElement = document.createElement('div');
             lineElement.className = 'compass-line';
@@ -36,12 +36,28 @@ const AppController = {
             const landmarkElement = document.createElement('div');
             landmarkElement.className = 'compass-landmark';
             landmarkElement.id = `compass-${landmarkId}`;
+            landmarkElement.setAttribute('aria-label', landmark.displayName || landmarkId);
             
             // Create image element
             const imgElement = document.createElement('img');
             imgElement.src = `images/${landmarkId}.png`;
-            imgElement.alt = landmarkId;
+            imgElement.alt = landmark.displayName || landmarkId;
+            imgElement.loading = 'lazy';
+            imgElement.decoding = 'async';
+
+            // Create a text fallback so newly added landmarks remain visible
+            // even before matching image files are added to the images folder.
+            const fallbackElement = document.createElement('span');
+            fallbackElement.className = 'landmark-fallback hidden';
+            fallbackElement.textContent = landmark.shortName || landmark.displayName || landmarkId;
+
+            imgElement.addEventListener('error', function() {
+                imgElement.classList.add('hidden');
+                fallbackElement.classList.remove('hidden');
+            }, { once: true });
+
             landmarkElement.appendChild(imgElement);
+            landmarkElement.appendChild(fallbackElement);
             
             compassCircle.appendChild(landmarkElement);
         });
@@ -99,6 +115,7 @@ const AppController = {
         console.log('UI:', AppState.ui);
         console.log('Sensors:', AppState.sensors);
         console.log('Landmarks:', landmarks);
+        console.log('Calculated Landmarks:', AppState.landmarks.calculated);
         console.log('=====================================');
     },
     
@@ -133,6 +150,9 @@ const AppController = {
         AppState.sensors = {
             orientationSupported: false,
             permissionGranted: false
+        };
+        AppState.landmarks = {
+            calculated: new Map()
         };
         
         console.log('Application state has been reset');

--- a/scripts/calculations.js
+++ b/scripts/calculations.js
@@ -9,6 +9,15 @@
 const CalculationUtils = {
     
     /**
+     * Convert degrees to radians.
+     * @param {number} degrees - Angle in degrees
+     * @returns {number} Angle in radians
+     */
+    toRadians(degrees) {
+        return degrees * Math.PI / 180;
+    },
+
+    /**
      * Calculates the bearing (direction) from one coordinate to another using spherical trigonometry
      * @param {number} lat1 - Latitude of the starting point
      * @param {number} lng1 - Longitude of the starting point
@@ -17,9 +26,9 @@ const CalculationUtils = {
      * @returns {number} Bearing in degrees (0-360)
      */
     calculateBearing(lat1, lng1, lat2, lng2) {
-        const dLng = (lng2 - lng1) * Math.PI / 180;
-        const lat1Rad = lat1 * Math.PI / 180;
-        const lat2Rad = lat2 * Math.PI / 180;
+        const dLng = this.toRadians(lng2 - lng1);
+        const lat1Rad = this.toRadians(lat1);
+        const lat2Rad = this.toRadians(lat2);
         
         const y = Math.sin(dLng) * Math.cos(lat2Rad);
         const x = Math.cos(lat1Rad) * Math.sin(lat2Rad) -
@@ -40,14 +49,18 @@ const CalculationUtils = {
      */
     calculateDistance(lat1, lng1, lat2, lng2) {
         const R = 6371; // Earth's radius in kilometers
-        const dLat = (lat2 - lat1) * Math.PI / 180;
-        const dLng = (lng2 - lng1) * Math.PI / 180;
+        const lat1Rad = this.toRadians(lat1);
+        const lat2Rad = this.toRadians(lat2);
+        const dLat = this.toRadians(lat2 - lat1);
+        const dLng = this.toRadians(lng2 - lng1);
+        const sinDLat = Math.sin(dLat / 2);
+        const sinDLng = Math.sin(dLng / 2);
         
-        const a = Math.sin(dLat/2) * Math.sin(dLat/2) +
-                  Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
-                  Math.sin(dLng/2) * Math.sin(dLng/2);
+        const a = sinDLat * sinDLat +
+                  Math.cos(lat1Rad) * Math.cos(lat2Rad) *
+                  sinDLng * sinDLng;
         
-        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
         return R * c;
     },
     
@@ -97,32 +110,43 @@ const CalculationUtils = {
             }
         }
     },
+
+    /**
+     * Calculates and caches the bearing and distance for every configured landmark.
+     * These values only depend on the user's location, so they do not need to be
+     * recalculated on every compass heading update.
+     */
+    updateLandmarkCalculations() {
+        if (!AppState.location.current) return;
+
+        Object.entries(landmarks).forEach(([landmarkId, landmark]) => {
+            const bearing = this.calculateBearing(
+                AppState.location.current.lat,
+                AppState.location.current.lng,
+                landmark.latitude,
+                landmark.longitude
+            );
+
+            const distance = this.calculateDistance(
+                AppState.location.current.lat,
+                AppState.location.current.lng,
+                landmark.latitude,
+                landmark.longitude
+            );
+
+            AppState.landmarks.calculated.set(landmarkId, { bearing, distance });
+        });
+    },
     
     /**
      * Calculates directions and distances to all landmarks from the current position
-     * Enhanced version that includes distance calculations
+     * Enhanced version that includes cached distance calculations
      */
     calculateAllDirections() {
         if (!AppState.location.current) return;
-        
-        Object.keys(landmarks).forEach(landmarkId => {
-            const landmark = landmarks[landmarkId];
-            
-            // Calculate bearing
-            const bearing = this.calculateBearing(
-                AppState.location.current.lat, AppState.location.current.lng,
-                landmark.latitude, landmark.longitude
-            );
-            
-            // Calculate distance
-            const distance = this.calculateDistance(
-                AppState.location.current.lat, AppState.location.current.lng,
-                landmark.latitude, landmark.longitude
-            );
-            
-            // Update both bearing and distance
-            LandmarkRenderer.updateLandmarkInfo(landmarkId, bearing, distance);
-        });
+
+        this.updateLandmarkCalculations();
+        LandmarkRenderer.updateAllLandmarksFromCache();
     }
 };
 

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,16 +1,110 @@
 // Landmark coordinate data
+// Each landmark can also define displayName and shortName.
+// - displayName is used for the image alt text and accessibility labels.
+// - shortName is used as a compact text fallback when no matching image exists.
+// Add a matching image as images/{landmarkId}.png when a custom icon is available.
 const landmarks = {
     'tower': {
+        displayName: 'Tokyo Tower',
+        shortName: 'Tokyo Tower',
         latitude: 35.6586,
         longitude: 139.7454
     },
     'tree': {
+        displayName: 'Tokyo Skytree',
+        shortName: 'Skytree',
         latitude: 35.7101,
         longitude: 139.8107
     },
     'fuji': {
+        displayName: 'Mount Fuji',
+        shortName: 'Fuji',
         latitude: 35.3606,
         longitude: 138.7274
+    },
+    'tokyo-station': {
+        displayName: 'Tokyo Station',
+        shortName: 'Tokyo Sta.',
+        latitude: 35.6812,
+        longitude: 139.7671
+    },
+    'imperial-palace': {
+        displayName: 'Imperial Palace',
+        shortName: 'Palace',
+        latitude: 35.6852,
+        longitude: 139.7528
+    },
+    'shibuya-scramble': {
+        displayName: 'Shibuya Scramble Crossing',
+        shortName: 'Shibuya',
+        latitude: 35.6595,
+        longitude: 139.7005
+    },
+    'tokyo-metropolitan-government': {
+        displayName: 'Tokyo Metropolitan Government Building',
+        shortName: 'Tocho',
+        latitude: 35.6896,
+        longitude: 139.6921
+    },
+    'rainbow-bridge': {
+        displayName: 'Rainbow Bridge',
+        shortName: 'Rainbow',
+        latitude: 35.6369,
+        longitude: 139.7630
+    },
+    'odaiba-statue-of-liberty': {
+        displayName: 'Odaiba Statue of Liberty',
+        shortName: 'Odaiba',
+        latitude: 35.6277,
+        longitude: 139.7713
+    },
+    'sensoji': {
+        displayName: 'Sensō-ji Temple',
+        shortName: 'Sensō-ji',
+        latitude: 35.7148,
+        longitude: 139.7967
+    },
+    'ueno-park': {
+        displayName: 'Ueno Park',
+        shortName: 'Ueno',
+        latitude: 35.7156,
+        longitude: 139.7745
+    },
+    'meiji-jingu': {
+        displayName: 'Meiji Jingu Shrine',
+        shortName: 'Meiji',
+        latitude: 35.6764,
+        longitude: 139.6993
+    },
+    'national-diet': {
+        displayName: 'National Diet Building',
+        shortName: 'Diet',
+        latitude: 35.6759,
+        longitude: 139.7449
+    },
+    'tokyo-dome': {
+        displayName: 'Tokyo Dome',
+        shortName: 'Dome',
+        latitude: 35.7056,
+        longitude: 139.7519
+    },
+    'roppongi-hills': {
+        displayName: 'Roppongi Hills Mori Tower',
+        shortName: 'Roppongi',
+        latitude: 35.6605,
+        longitude: 139.7292
+    },
+    'tokyo-big-sight': {
+        displayName: 'Tokyo Big Sight',
+        shortName: 'Big Sight',
+        latitude: 35.6298,
+        longitude: 139.7941
+    },
+    'haneda-airport': {
+        displayName: 'Haneda Airport',
+        shortName: 'Haneda',
+        latitude: 35.5494,
+        longitude: 139.7798
     }
 };
 

--- a/scripts/dom-cache.js
+++ b/scripts/dom-cache.js
@@ -44,6 +44,7 @@ const DOMCache = {
     // Dynamic landmark elements cache
     landmarks: new Map(),
     lines: new Map(),
+    distances: new Map(),
     
     // Cache initialization state
     initialized: false,
@@ -89,10 +90,17 @@ const DOMCache = {
     cacheLandmarkElements(landmarkId) {
         if (!this.landmarks.has(landmarkId)) {
             const landmarkElement = document.getElementById(`compass-${landmarkId}`);
-            const lineElement = document.getElementById(`line-${landmarkId}`);
-            
             if (landmarkElement) this.landmarks.set(landmarkId, landmarkElement);
+        }
+
+        if (!this.lines.has(landmarkId)) {
+            const lineElement = document.getElementById(`line-${landmarkId}`);
             if (lineElement) this.lines.set(landmarkId, lineElement);
+        }
+
+        if (!this.distances.has(landmarkId)) {
+            const distanceElement = document.getElementById(`distance-${landmarkId}`);
+            if (distanceElement) this.distances.set(landmarkId, distanceElement);
         }
     },
     
@@ -119,6 +127,18 @@ const DOMCache = {
         }
         return this.lines.get(landmarkId) || null;
     },
+
+    /**
+     * Get cached distance element
+     * @param {string} landmarkId - The landmark identifier
+     * @returns {HTMLElement|null} The cached distance element or null
+     */
+    getDistanceElement(landmarkId) {
+        if (!this.distances.has(landmarkId)) {
+            this.cacheLandmarkElements(landmarkId);
+        }
+        return this.distances.get(landmarkId) || null;
+    },
     
     /**
      * Clear all cached references (useful for cleanup)
@@ -126,6 +146,7 @@ const DOMCache = {
     clear() {
         this.landmarks.clear();
         this.lines.clear();
+        this.distances.clear();
         this.initialized = false;
     }
 };

--- a/scripts/landmark-renderer.js
+++ b/scripts/landmark-renderer.js
@@ -30,7 +30,7 @@ const LandmarkRenderer = {
      * @param {number} bearing - The bearing angle in degrees (not used since rotation is handled by parent line)
      */
     updateLandmarkDistance(landmarkId, distanceKm, bearing) {
-        const distanceElement = document.getElementById(`distance-${landmarkId}`);
+        const distanceElement = DOMCache.getDistanceElement(landmarkId);
         if (distanceElement) {
             distanceElement.textContent = CalculationUtils.formatDistance(distanceKm);
         }
@@ -56,21 +56,16 @@ const LandmarkRenderer = {
             const x = Math.cos(angleRad) * radius;
             const y = Math.sin(angleRad) * radius;
             
-            // Get image dimensions
-            const imgElement = compassLandmarkElement.querySelector('img');
-            let imageWidth = null;
-            let imageHeight = null;
-            
-            if (imgElement && imgElement.offsetWidth > 0) {
-                imageWidth = imgElement.offsetWidth;
-                imageHeight = imgElement.offsetHeight;
-            }
+            // Get visible child dimensions from the image or text fallback
+            const visualElement = compassLandmarkElement.querySelector('img:not(.hidden), .landmark-fallback:not(.hidden)');
+            const visualWidth = visualElement && visualElement.offsetWidth > 0 ? visualElement.offsetWidth : 40;
+            const visualHeight = visualElement && visualElement.offsetHeight > 0 ? visualElement.offsetHeight : 28;
             
             // Position relative to compass center
             compassLandmarkElement.style.left = '50%';
             compassLandmarkElement.style.top = '50%';
-            compassLandmarkElement.style.marginLeft = - (imageWidth / 2) + 'px';
-            compassLandmarkElement.style.marginTop = - imageHeight + 20 + 'px';
+            compassLandmarkElement.style.marginLeft = - (visualWidth / 2) + 'px';
+            compassLandmarkElement.style.marginTop = - visualHeight + 20 + 'px';
             
             // Apply final transform
             compassLandmarkElement.style.transform = `translate(${x}px, ${y}px)`;
@@ -79,29 +74,36 @@ const LandmarkRenderer = {
             this.updateCompassLine(landmarkId, relativeBearing);
         }
     },
+
+    /**
+     * Updates one landmark using the cached calculation values.
+     * @param {string} landmarkId - The landmark identifier
+     */
+    updateLandmarkFromCache(landmarkId) {
+        const calculated = AppState.landmarks.calculated.get(landmarkId);
+        if (!calculated) return;
+
+        this.updateCompassLandmark(landmarkId, calculated.bearing);
+        this.updateLandmarkDistance(landmarkId, calculated.distance, calculated.bearing);
+    },
+
+    /**
+     * Updates all landmark positions and distance displays from cached calculations.
+     */
+    updateAllLandmarksFromCache() {
+        AppState.landmarks.calculated.forEach((calculated, landmarkId) => {
+            this.updateCompassLandmark(landmarkId, calculated.bearing);
+            this.updateLandmarkDistance(landmarkId, calculated.distance, calculated.bearing);
+        });
+    },
     
     /**
      * Updates all landmark positions on the compass when device orientation changes
-     * Recalculates and repositions all landmark icons and distance displays based on current heading
+     * Reuses cached bearing and distance values because only the device heading changes.
      */
     updateAllLines() {
         if (!AppState.location.current) return;
-        
-        Object.keys(landmarks).forEach(landmarkId => {
-            const landmark = landmarks[landmarkId];
-            const bearing = CalculationUtils.calculateBearing(
-                AppState.location.current.lat, AppState.location.current.lng,
-                landmark.latitude, landmark.longitude
-            );
-            const distance = CalculationUtils.calculateDistance(
-                AppState.location.current.lat, AppState.location.current.lng,
-                landmark.latitude, landmark.longitude
-            );
-            
-            // Update both landmark position and distance display
-            this.updateCompassLandmark(landmarkId, bearing);
-            this.updateLandmarkDistance(landmarkId, distance, bearing);
-        });
+        this.updateAllLandmarksFromCache();
     },
     
     /**

--- a/scripts/state-manager.js
+++ b/scripts/state-manager.js
@@ -28,6 +28,11 @@ const AppState = {
     sensors: {
         orientationSupported: false,
         permissionGranted: false
+    },
+    landmarks: {
+        // Stores calculated bearing and distance values by landmark ID.
+        // These values are recalculated only when the user's location changes.
+        calculated: new Map()
     }
 };
 

--- a/style.css
+++ b/style.css
@@ -200,13 +200,33 @@ header p#note {
     display: flex;
 }
 
-.compass-landmark.visible img {
+.compass-landmark.visible img,
+.compass-landmark.visible .landmark-fallback {
     transform-origin: center bottom;
     animation: landmarkHeightAnimation 0.5s ease-out forwards;
 }
 
 .compass-landmark img {
     object-fit: cover;
+}
+
+.landmark-fallback {
+    max-width: 56px;
+    padding: 4px 6px;
+    border: 2px solid #667eea;
+    border-radius: 10px;
+    background: #ffffff;
+    color: #667eea;
+    font-size: 0.62rem;
+    font-weight: bold;
+    line-height: 1.1;
+    text-align: center;
+    white-space: normal;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+
+.hidden {
+    display: none !important;
 }
 
 /* ========================================


### PR DESCRIPTION
Summary:
- Add more Tokyo landmarks.
- Cache landmark bearing and distance calculations.
- Add text fallback labels for landmarks without image files.
- Cache distance label DOM elements.

Note: Browser sensor testing was not run in this environment.